### PR TITLE
Added downstream inheritance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,13 @@ RUN chown -R ${RHUSER}. ${HOME}
 RUN usermod -a -G wheel --shell /bin/bash ${RHUSER}
 RUN echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
 
-# Forward environment variables to downstream images
+# Switch to the user and change to user directory
+USER ${RHUSER}
+WORKDIR ${HOME}
+
+# Downstream image kicks off as root user
+# And gains environment variables
+ONBUILD USER root
 ONBUILD ENV RHUSER ${RHUSER}
 ONBUILD ENV HOME ${HOME}
 ONBUILD ENV OSSIEHOME ${OSSIEHOME}
@@ -45,20 +51,8 @@ ONBUILD ENV SDRROOT ${SDRROOT}
 ONBUILD ENV PYTHONPATH ${PYTHONPATH}
 ONBUILD ENV PATH ${PATH}
 
-# Clean and configure omni to kickoff on startup
-RUN ${OSSIEHOME}/bin/cleanomni
-RUN /sbin/chkconfig --level 345 omniNames on
-RUN /sbin/chkconfig --level 345 omniEvents on
-
-# Run nodeconfig as the user
-USER ${RHUSER}
-
-# Change back to user's directory
-WORKDIR ${HOME}
-
-# Downstream image kicks off as root user
-ONBUILD USER root
-
+# Expose omni's ports
 EXPOSE 2809
 EXPOSE 11169
+
 CMD ["/bin/bash", "-l"]

--- a/README.md
+++ b/README.md
@@ -7,12 +7,9 @@ The default command for this image runs a bash shell as the 'redhawk' user.  Thi
 
 	docker run -i -t ryanbauman/redhawk
 
-The image comes with the omniNames and omniEvents servers installed and configured.  Start them with:
+The image comes with the omniNames and omniEvents servers installed and configured to run automatically on startup.
 
-    sudo service omniNames start
-    sudo service omniEvents start
-
-#REDHAWK IDE support
+# REDHAWK IDE support
 The REDHAWK IDE has been intentionally omitted from the yum repository this image draws from. To enable IDE support in your docker container, download the standalone IDE from sourceforge and invoke the image appropriately.
 
 If you are on an SELinux enabled host, assign the appropriate context to the /tmp/.X11-unix directory as described [here]( https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Resource_Management_and_Linux_Containers_Guide/sec-Sharing_Data_Across_Containers.html):
@@ -38,5 +35,4 @@ Install minimal gtk support:
 Verify that the REDHAWK IDE can be launched and displays correctly on the host system:
 
     ./eclipse/eclipse &
-
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ The default command for this image runs a bash shell as the 'redhawk' user.  Thi
 
 	docker run -i -t ryanbauman/redhawk
 
-The image comes with the omniNames and omniEvents servers installed and configured to run automatically on startup.
+The image comes with the omniNames and omniEvents servers installed and configured.  Start them with if you are not running the services elsewhere on the local host (per omniORB.cfg):
+
+    sudo service omniNames start
+    sudo service omniEvents start
 
 # REDHAWK IDE support
 The REDHAWK IDE has been intentionally omitted from the yum repository this image draws from. To enable IDE support in your docker container, download the standalone IDE from sourceforge and invoke the image appropriately.
@@ -35,4 +38,5 @@ Install minimal gtk support:
 Verify that the REDHAWK IDE can be launched and displays correctly on the host system:
 
     ./eclipse/eclipse &
+
 


### PR DESCRIPTION
Thanks for this by the way!  Very slick.

I started down the same path as you (docker-nodebooter, repeating this docker's settings) and decided to change course slightly so that this image could be inherited by downstream images.  So I removed the nodeconfig call and exposed the environment variables using `ONBUILD`.  My reasoning for the former is that derivatives of this image might not need a default node defined.  On the latter, it allows derivatives to discover the built REDHAWK environment variables, user name, etc. to go off and build a domain, import nodes, etc.